### PR TITLE
fix: move the validateUpdate12 script to a separate Composer script

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ for your setup.
 After that you can create the project:
 
 ```
-composer create-project openfed/openfed-project:~12.3.0 MYPROJECT
+composer create-project openfed/openfed-project:~12.5.0 MYPROJECT
 ```
 
 ### Update

--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,9 @@
     "extra": {
         "merge-plugin": {
             "require": [
-                "composer.openfed.json"
+                "composer.openfed.json",
+                "docroot/modules/contrib/ckeditor_codemirror/composer.libraries.json",
+                "docroot/modules/contrib/webform/composer.libraries.json"
             ],
             "recurse": true,
             "replace": false,

--- a/composer.openfed.json
+++ b/composer.openfed.json
@@ -1,6 +1,6 @@
 {
     "name": "openfed/openfed-project",
-    "description": "Project template for Drupal 9 sites built with the Openfed distribution.",
+    "description": "Project template for Drupal 10 sites built with the Openfed distribution.",
     "type": "project",
     "license": "GPL-2.0-or-later",
     "authors": [
@@ -20,7 +20,7 @@
         }
     ],
     "require": {
-        "openfed/openfed": "12.3.*",
+        "openfed/openfed": "12.5.*",
         "cweagans/composer-patches": "^1.7.0",
         "szeidler/composer-patches-cli": "^1.0"
     },

--- a/composer.openfed.json
+++ b/composer.openfed.json
@@ -26,14 +26,14 @@
     },
     "require-dev": { },
     "scripts": {
-        "pre-update-cmd": [
-            "OpenfedProject\\composer\\OpenfedValidations::validateUpdate12"
-        ],
         "post-install-cmd": [
             "OpenfedProject\\composer\\ScriptHandler::createRequiredFiles"
         ],
         "post-update-cmd": [
             "composer install"
+        ],
+        "project-validate-update12": [
+            "OpenfedProject\\composer\\OpenfedValidations::validateUpdate12"
         ],
         "project-update": [
             "OpenfedProject\\composer\\OpenfedUpdate::update"


### PR DESCRIPTION
The problem with the current implementation was that the script was run on composer update. But the script was actually run **after** the composer-patches plugin removed modules to be patched, but **before** the module was installed and patched. This caused Drupal not to bootstrap and the script to fail.

It should be run manually now via `composer run project-validate-update12`.

This fix goes hand in hand with a [fix in the actual script](https://github.com/openfed/openfed/pull/105).

To be backported to 12.3 as well...